### PR TITLE
Add --allow=devel and remove sdk-extensions

### DIFF
--- a/build.py
+++ b/build.py
@@ -401,6 +401,7 @@ def parse_repo():
                 '--share=network',
                 '--device=dri',
                 '--filesystem=host',
+                '--allow=devel',
                 '--persist=' + product_json['dataFolderName'],
                 '--talk-name=org.freedesktop.Notifications'
             ],
@@ -413,9 +414,6 @@ def parse_repo():
                     'no-autodownload': True
                 }
             },
-            'sdk-extensions': [
-                'org.freedesktop.Sdk.Extension.golang'
-            ],
             'modules': [
                 {
                     'name': 'libsecret',

--- a/com.visualstudio.code.oss.json
+++ b/com.visualstudio.code.oss.json
@@ -11,6 +11,7 @@
     "--share=network",
     "--device=dri",
     "--filesystem=host",
+    "--allow=devel",
     "--persist=.vscode-oss",
     "--talk-name=org.freedesktop.Notifications"
   ],
@@ -23,9 +24,6 @@
       "no-autodownload": true
     }
   },
-  "sdk-extensions": [
-    "org.freedesktop.Sdk.Extension.golang"
-  ],
   "modules": [
     {
       "name": "libsecret",


### PR DESCRIPTION
--allow=devel auto uses the SDK as the runtime and allows for using
debugging tools such as gdb. Furthermore it automatically uses SDK
extensions.

Closes #29