### PR TITLE
Allow vscode OSS to talk to the host shell 

### DIFF
--- a/com.visualstudio.code.oss.json
+++ b/com.visualstudio.code.oss.json
@@ -22,7 +22,8 @@
     "--device=dri",
     "--filesystem=host",
     "--persist=.vscode-oss",
-    "--talk-name=org.freedesktop.Notifications"
+    "--talk-name=org.freedesktop.Notifications",
+    "--talk-name=org.freedesktop.Flatpak"
   ],
   "modules": [
     {


### PR DESCRIPTION
This allows your to tell flatpak to pass commands to the host shell from inside the VSCODE shell:

" flatpak-spawn --host go" for example will call the host go installation.